### PR TITLE
Fix favicon in doc pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, FastAPI
-from fastapi.staticfiles import StaticFiles
 
 from . import VERSION
 from .routers import about, auth, default
@@ -8,8 +7,9 @@ app = FastAPI(
     title="Safe Auth Service",
     description="API to grant JWT tokens for using across the Safe Core{API} infrastructure.",
     version=VERSION,
+    docs_url=None,
+    redoc_url=None,
 )
-app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # Router configuration
 api_v1_router = APIRouter(


### PR DESCRIPTION
Currently, we already have custom pages for `swagger` and `redoc`, we need init the app with `docs_url=None` and `redoc_url=None` to use them and use the Safe favicon (and other customizations). 

The static files are been serving from `nginx` and it's not necessary to mount the static directory in FastAPI 
