### PR TITLE
Bump safe-eth-py, web3, siwe and python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     services:
       redis:
         image: redis

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Python CI](https://github.com/safe-global/safe-auth-service/actions/workflows/ci.yml/badge.svg)](https://github.com/safe-global/safe-auth-service/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-auth-service/badge.svg?branch=main)](https://coveralls.io/github/safe-global/safe-auth-service?branch=main)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-![Python 3.12](https://img.shields.io/badge/Python-3.12-blue.svg)
+![Python 3.13](https://img.shields.io/badge/Python-3.13-blue.svg)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/safeglobal/safe-auth-service?label=Docker&sort=semver)](https://hub.docker.com/r/safeglobal/safe-auth-service)
 
 

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from safe_eth.util.util import to_0x_hex_str
 
 from ...main import app
 
@@ -75,10 +76,10 @@ class TestRouterAuth(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         obtained_siwe_message = response.json().get("message")
 
-        private_key = account.key.hex()
+        private_key = to_0x_hex_str(account.key)
         eip191_message = encode_defunct(text=obtained_siwe_message)
         signed_message = Account.sign_message(eip191_message, private_key=private_key)
-        signature = signed_message.signature.hex()
+        signature = to_0x_hex_str(signed_message.signature)
 
         jwt_private_key = rsa.generate_private_key(
             public_exponent=65537,

--- a/app/tests/services/test_message_service.py
+++ b/app/tests/services/test_message_service.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from eth_typing import HexStr
+from safe_eth.util.util import to_0x_hex_str
 from siwe.siwe import ISO8601Datetime, SiweMessage, VersionEnum
 
 from ...cache import get_redis
@@ -138,10 +140,10 @@ class TestSiweMessageService(unittest.TestCase):
         )
         message_str = siwe_message.prepare_message()
 
-        private_key = account.key.hex()
+        private_key = to_0x_hex_str(account.key)
         eip191_message = encode_defunct(text=siwe_message.prepare_message())
         signed_message = Account.sign_message(eip191_message, private_key=private_key)
-        signature = signed_message.signature.hex()
+        signature = to_0x_hex_str(signed_message.signature)
 
         # Valid message
         verify_siwe_message(message_str, signature)
@@ -152,10 +154,10 @@ class TestSiweMessageService(unittest.TestCase):
         # Invalid message format
         message_str = "Invalid SIWE message"
 
-        private_key = account.key.hex()
+        private_key = to_0x_hex_str(account.key)
         eip191_message = encode_defunct(text=siwe_message.prepare_message())
         signed_message = Account.sign_message(eip191_message, private_key=private_key)
-        signature = signed_message.signature.hex()
+        signature = to_0x_hex_str(signed_message.signature)
 
         with self.assertRaises(InvalidMessageFormatError):
             verify_siwe_message(message_str, signature)
@@ -175,10 +177,10 @@ class TestSiweMessageService(unittest.TestCase):
         )
         message_str = siwe_message.prepare_message()
 
-        private_key = account.key.hex()
+        private_key = to_0x_hex_str(account.key)
         eip191_message = encode_defunct(text=siwe_message.prepare_message())
         signed_message = Account.sign_message(eip191_message, private_key=private_key)
-        signature = signed_message.signature.hex()
+        signature = to_0x_hex_str(signed_message.signature)
 
         with self.assertRaises(InvalidNonceError):
             verify_siwe_message(message_str, signature)
@@ -198,10 +200,10 @@ class TestSiweMessageService(unittest.TestCase):
         )
         message_str = siwe_message.prepare_message()
 
-        private_key = account.key.hex()
+        private_key = to_0x_hex_str(account.key)
         eip191_message = encode_defunct(text=siwe_message.prepare_message())
         signed_message = Account.sign_message(eip191_message, private_key=private_key)
-        signature = signed_message.signature.hex()
+        signature = to_0x_hex_str(signed_message.signature)
 
         with self.assertRaises(InvalidSignatureError):
             verify_siwe_message(message_str, signature)
@@ -219,7 +221,7 @@ class TestSiweMessageService(unittest.TestCase):
             expiration_time=expiration_time,
         )
         message_str = siwe_message.prepare_message()
-        signature = "0x455aaa"
+        signature = HexStr("0x455aaa")
 
         with self.assertRaises(InvalidSignatureError):
             verify_siwe_message(message_str, signature)

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 EXPOSE 8888/tcp
 ARG APP_HOME=/app

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,6 +2,6 @@ fastapi[all]==0.115.7
 pydantic-settings==2.6.1
 pyjwt[crypto]==2.10.0
 redis[hiredis]==5.2.0
-safe-eth-py==6.0.0b41
-siwe==4.2.0
-web3==6.20.2
+safe-eth-py==7.1.1
+siwe==4.4.0
+web3==7.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ known_fastapi = fastapi,pydantic
 sections = FUTURE,STDLIB,FASTAPI,THIRDPARTY,GNOSIS,FIRSTPARTY,LOCALFOLDER
 
 [mypy]
-python_version = 3.12
+python_version = 3.13
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True


### PR DESCRIPTION
Updated versions:

- `safe-eth-py`: 7.1.1
- `web3`: 7.8.0
- `siwe`: 4.4.0
- `Python`: 3.13