### PR TITLE
Add greenlet to requirements

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,6 +2,7 @@ alembic==1.14.1
 asyncpg==0.30.0
 Faker==37.1.0
 fastapi[all]==0.115.12
+greenlet==3.1.1
 ipython>=9.0.2
 pydantic-settings==2.8.1
 pyjwt[crypto]==2.10.1


### PR DESCRIPTION
# Description
Greenlet is required for SQLAlchemy. 