### PR TITLE
Add ExpiredSignatureError exception to verify when JWT token is expired

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -4,7 +4,7 @@ from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 
 import jwt
-from jwt import InvalidTokenError
+from jwt import ExpiredSignatureError, InvalidTokenError
 from starlette import status
 
 from app.config import settings
@@ -22,7 +22,7 @@ async def get_user_from_jwt_token(
             algorithms=[settings.JWT_ALGORITHM],
             audience=settings.JWT_AUDIENCE,
         )
-    except InvalidTokenError as e:
+    except (InvalidTokenError, ExpiredSignatureError) as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not decode credentials",

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -22,7 +22,13 @@ async def get_user_from_jwt_token(
             algorithms=[settings.JWT_ALGORITHM],
             audience=settings.JWT_AUDIENCE,
         )
-    except (InvalidTokenError, ExpiredSignatureError) as e:
+    except ExpiredSignatureError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="The provided JWT token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from e
+    except InvalidTokenError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not decode credentials",

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -1,0 +1,39 @@
+import datetime
+import unittest
+
+from fastapi import HTTPException
+
+from app.config import settings
+from app.routers.auth import get_user_from_jwt_token
+from app.services.jwt_service import JwtService
+
+
+class TestAuth(unittest.IsolatedAsyncioTestCase):
+
+    async def test_valid_token(self):
+        token = JwtService().create_access_token(
+            "user123", datetime.timedelta(minutes=5), settings.JWT_AUDIENCE, {}
+        )
+
+        user = await get_user_from_jwt_token(token)
+        self.assertEqual(user["sub"], "user123")
+
+    async def test_invalid_token(self):
+        invalid_token = "invalid.token.value"
+
+        with self.assertRaises(HTTPException) as context:
+            await get_user_from_jwt_token(invalid_token)
+
+        self.assertEqual(context.exception.status_code, 401)
+        self.assertEqual(context.exception.detail, "Could not decode credentials")
+
+    async def test_expired_token(self):
+        token = JwtService().create_access_token(
+            "user123", datetime.timedelta(minutes=-1), settings.JWT_AUDIENCE, {}
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            await get_user_from_jwt_token(token)
+
+        self.assertEqual(context.exception.status_code, 401)
+        self.assertEqual(context.exception.detail, "Could not decode credentials")

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -36,4 +36,4 @@ class TestAuth(unittest.IsolatedAsyncioTestCase):
             await get_user_from_jwt_token(token)
 
         self.assertEqual(context.exception.status_code, 401)
-        self.assertEqual(context.exception.detail, "Could not decode credentials")
+        self.assertEqual(context.exception.detail, "The provided JWT token has expired")


### PR DESCRIPTION
The jwt.ExpiredSignatureError exception is thrown when the token is expired.

https://pyjwt.readthedocs.io/en/stable/usage.html#expiration-time-claim-exp