### PR TITLE
Set SecretStr type for passwords

### DIFF
--- a/app/models/users.py
+++ b/app/models/users.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, SecretStr
 
 from typing_extensions import Annotated
 
-passwordType = Annotated[str, Field(min_length=8)]
+passwordType = Annotated[SecretStr, Field(min_length=8)]
 
 
 class Token(BaseModel):

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -18,6 +18,7 @@ from ..models.users import (
     RegistrationUserResponse,
     ResetPasswordRequest,
     Token,
+    passwordType,
 )
 from ..services.user_service import (
     TemporaryTokenExists,
@@ -78,7 +79,7 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]) -> T
     user_service = UserService()
     token = await user_service.login_user(
         form_data.username,
-        form_data.password,
+        passwordType(form_data.password),
     )
     return token
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -11,7 +11,7 @@ from starlette import status
 from ..config import settings
 from ..datasources.cache.redis import get_redis
 from ..datasources.db.models import User
-from ..models.users import Token
+from ..models.users import Token, passwordType
 from .jwt_service import JwtService
 
 
@@ -50,10 +50,14 @@ class UserService:
     def __init__(self):
         self.jwt_service = JwtService()
 
-    def verify_password(self, plain_password: str, hashed_password: str) -> bool:
-        return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
+    def verify_password(
+        self, plain_password: passwordType, hashed_password: str
+    ) -> bool:
+        return bcrypt.checkpw(
+            plain_password.get_secret_value().encode(), hashed_password.encode()
+        )
 
-    def hash_password(self, password: str) -> str:
+    def hash_password(self, password: passwordType) -> str:
         """
         Args:
             password:
@@ -61,7 +65,9 @@ class UserService:
         Returns:
             A string like '$2b$12$yadYxE5ZNfF28M.M00gha.SEaPF2Z.ICEqgIhbhZrgCrCR7PEK7uS'
         """
-        return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+        return bcrypt.hashpw(
+            password.get_secret_value().encode(), bcrypt.gensalt()
+        ).decode()
 
     def temporary_token_generate(
         self,
@@ -118,7 +124,9 @@ class UserService:
         )
         return token
 
-    async def register_user(self, email: str, password: str, token: str) -> str:
+    async def register_user(
+        self, email: str, password: passwordType, token: str
+    ) -> str:
         """
         Args:
             email:
@@ -145,13 +153,15 @@ class UserService:
         await user.create()
         return user_uuid
 
-    async def authenticate_user(self, email: str, password: str) -> User | None:
+    async def authenticate_user(
+        self, email: str, password: passwordType
+    ) -> User | None:
         user = await User.get_by_email(email)
         if user and self.verify_password(password, user.hashed_password):
             return user
         return None
 
-    async def login_user(self, email: str, password: str) -> Token:
+    async def login_user(self, email: str, password: passwordType) -> Token:
         user = await self.authenticate_user(email, password)
         if not user:
             raise HTTPException(
@@ -166,7 +176,7 @@ class UserService:
         return Token(access_token=access_token, token_type="bearer")
 
     async def change_password(
-        self, user: User, old_password: str | None, new_password: str
+        self, user: User, old_password: passwordType | None, new_password: passwordType
     ) -> bool:
         """
         Changes the password to the provided user.
@@ -214,7 +224,9 @@ class UserService:
         )
         return token
 
-    async def reset_password(self, email: str, token: str, new_password: str) -> bool:
+    async def reset_password(
+        self, email: str, token: str, new_password: passwordType
+    ) -> bool:
         """
         Changes a password for a user with the provided password.
         Checks that the email was verified from the provided token.

--- a/app/tests/datasources/db/factory.py
+++ b/app/tests/datasources/db/factory.py
@@ -4,18 +4,19 @@ from typing import Tuple
 import faker
 
 from app.datasources.db.models import ApiKey, User
+from app.models.users import passwordType
 from app.services.user_service import UserService
 
 fake = faker.Faker()
 
 
-async def generate_random_user() -> Tuple[User, str]:
+async def generate_random_user() -> Tuple[User, passwordType]:
     """
     Generate a random user with mail and password.
     Returns: User object and plain password
 
     """
-    password = fake.password()
+    password = passwordType(fake.password(length=8))
     user_service = UserService()
     user = await User(
         email=fake.email(), hashed_password=user_service.hash_password(password)

--- a/app/tests/routers/test_users.py
+++ b/app/tests/routers/test_users.py
@@ -9,7 +9,7 @@ from app.datasources.cache.redis import get_redis
 from app.datasources.db.connector import db_session_context
 from app.datasources.db.models import User
 from app.main import app
-from app.models.users import RegistrationUser
+from app.models.users import RegistrationUser, passwordType
 
 from ..datasources.db.async_db_test_case import AsyncDbTestCase
 
@@ -33,7 +33,7 @@ class TestUsers(AsyncDbTestCase):
             The same example user so tests can be reused
         """
         token = "random-token"
-        password = "random-password"
+        password = passwordType("random-password")
         email = "testing@safe.global"
         return RegistrationUser(token=token, password=password, email=email)
 
@@ -60,7 +60,7 @@ class TestUsers(AsyncDbTestCase):
         user = self.get_example_registration_user()
         payload = {
             "token": user.token,
-            "password": user.password,
+            "password": user.password.get_secret_value(),
             "email": user.email,
         }
 
@@ -102,7 +102,7 @@ class TestUsers(AsyncDbTestCase):
 
         payload = {
             "username": user.email,
-            "password": user.password,
+            "password": user.password.get_secret_value(),
         }
 
         # User database is empty, it should not work
@@ -114,7 +114,7 @@ class TestUsers(AsyncDbTestCase):
         # Password is not valid
         payload_2 = {
             "username": user.email,
-            "password": user.password + "not-valid",
+            "password": user.password.get_secret_value() + "not-valid",
         }
         response = self.client.post("/api/v1/users/login", data=payload_2)
         self.assertEqual(response.status_code, 401)
@@ -140,7 +140,7 @@ class TestUsers(AsyncDbTestCase):
         user = self.get_example_registration_user()
         new_password = fake.password()
         change_password_payload = {
-            "old_password": user.password,
+            "old_password": user.password.get_secret_value(),
             "new_password": new_password,
         }
         response = self.client.post(
@@ -152,7 +152,7 @@ class TestUsers(AsyncDbTestCase):
 
         login_payload = {
             "username": user.email,
-            "password": user.password,
+            "password": user.password.get_secret_value(),
         }
         await self.test_register()
         response = self.client.post("/api/v1/users/login", data=login_payload)

--- a/app/tests/services/test_user_service.py
+++ b/app/tests/services/test_user_service.py
@@ -4,6 +4,7 @@ import faker
 
 from ...datasources.db.connector import db_session_context
 from ...datasources.db.models import User
+from ...models.users import passwordType
 from ...services.user_service import (
     TemporaryTokenExists,
     TemporaryTokenNotValid,
@@ -26,8 +27,8 @@ class TestApiKeyService(AsyncDbTestCase):
             user_service.verify_password(old_password, user.hashed_password)
         )
 
-        new_password = fake.password()
-        wrong_old_password = fake.password()
+        new_password = passwordType(fake.password())
+        wrong_old_password = passwordType(fake.password())
         with self.assertRaises(WrongPassword):
             await user_service.change_password(user, wrong_old_password, new_password)
 
@@ -63,7 +64,7 @@ class TestApiKeyService(AsyncDbTestCase):
         assert right_token is not None
         self.assertEqual(user.email, user.email)
         wrong_token = str(uuid.uuid4())
-        new_password = fake.password()
+        new_password = passwordType(fake.password())
 
         with self.assertRaises(TemporaryTokenNotValid):
             await user_service.reset_password(user.email, wrong_token, new_password)


### PR DESCRIPTION
# Description
Set `SectretStr` as type for passwords instead plain string to protect the password on internal logging. 
