### PR TITLE
Add connection with apisix when api key is created or deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ To open an interactive Python shell within a Docker container and query the data
 ```
 Example usage:
 ```python
-users = await Users.get_all()
+from app.datasources.db.models import User
+
+users = await User.get_all()
 print(users[0].email)
 ```
 Call `await restore_session()` to reopen a new session.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ To open an interactive Python shell within a Docker container and query the data
 ```
 Example usage:
 ```python
-from app.datasources.db.models import User
-
 users = await User.get_all()
 print(users[0].email)
 ```

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,9 @@ class Settings(BaseSettings):
     APISIX_API_KEY: str = ""
     APISIX_CONNECTIONS_POOL_SIZE: int = 100
 
+    # Apisix Consumer Groups (Payment Plans) ---------------
+    APISIX_FREEMIUM_CONSUMER_GROUP_NAME: str = ""
+
     # Datadog ---------------
     DATADOG_BASE_URL: str = "https://api.datadoghq.eu"
     DATADOG_API_KEY: str = ""

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -44,7 +44,7 @@ async def get_jwt_info_from_auth_token(
 
 
 def get_user_id_from_jwt(jwt_info: dict) -> uuid.UUID:
-    return jwt_info["sub"]
+    return uuid.UUID(jwt_info["sub"])
 
 
 async def get_user_from_jwt(jwt_info: dict) -> User:

--- a/app/services/api_key_service.py
+++ b/app/services/api_key_service.py
@@ -51,11 +51,14 @@ async def delete_api_key_by_id(api_key_id: uuid.UUID, user_id: uuid.UUID) -> boo
     Returns: True if the api key was deleted, False otherwise.
 
     """
-    api_key_deleted = await ApiKey.delete_by_ids(api_key_id, user_id)
-    if api_key_deleted:
-        api_key_subject = f"{user_id.hex}_{api_key_id.hex}"
-        await get_apisix_client().delete_consumer(api_key_subject)
-    return api_key_deleted
+    stored_api_key = await ApiKey.get_by_ids(api_key_id, user_id)
+
+    if not stored_api_key:
+        return False
+
+    api_key_subject = f"{user_id.hex}_{api_key_id.hex}"
+    await get_apisix_client().delete_consumer(api_key_subject)
+    return await ApiKey.delete_by_ids(api_key_id, user_id)
 
 
 async def get_api_key_by_ids(

--- a/app/services/jwt_service.py
+++ b/app/services/jwt_service.py
@@ -35,6 +35,7 @@ class JwtService:
         to_encode = {
             "iss": settings.JWT_ISSUER,
             "sub": subject,
+            "key": subject,
             "aud": audience,
             "exp": expire,
             "data": data.copy(),

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -24,6 +24,7 @@ class TestAuth(AsyncDbTestCase):
 
         user = await get_jwt_info_from_auth_token(token)
         self.assertEqual(user["sub"], "user123")
+        self.assertEqual(user["key"], "user123")
 
     async def test_invalid_token(self):
         invalid_token = "invalid.token.value"


### PR DESCRIPTION
- Closes #109 

To be considered:

- I have tried the global setting of `key_claim_name` in the [JWT plugin](https://apisix.apache.org/docs/apisix/plugins/jwt-auth/) but it only works at route level. It is not possible to use `sub` in the JWT plugin global configuration in Apisix. That's why I add the `key` attribute to the JWT token. I keep `sub` to comply with the standard.

- The consumers id in Apisix has to comply with this regex `^[a-zA-Z0-9_]+$`. Validated in local tests. That's why the Uuid is transformed to hex when composing the ApiKey sub and Apisix consumer.


Full flow has been validated generating an api key through the Api and configuring a route in Apisix local.
![Screenshot 2025-05-02 at 17 47 47](https://github.com/user-attachments/assets/e57a9785-0d25-47e3-ae91-849839bae195)
![Screenshot 2025-05-02 at 17 57 25](https://github.com/user-attachments/assets/d30da534-cff8-45eb-b449-ee0c9ee33e0d)

