### PR TITLE
follow-up: Add connection with apisix when api key is created or deleted

### DIFF
--- a/app/services/api_key_service.py
+++ b/app/services/api_key_service.py
@@ -4,7 +4,6 @@ import uuid
 from pydantic import TypeAdapter
 
 from ..config import settings
-from ..datasources.api_gateway.apisix.apisix_client import get_apisix_client
 from ..datasources.db.models import ApiKey
 from ..models.api_key import ApiKeyPublic
 from ..services.jwt_service import JwtService
@@ -23,15 +22,10 @@ async def generate_api_key(user_id: uuid.UUID, description: str) -> ApiKeyPublic
 
     """
     api_key_id = uuid.uuid4()
-    api_key_subject = f"{user_id.hex}_{api_key_id.hex}"
-    await get_apisix_client().upsert_consumer(
-        api_key_subject,
-        description=description,
-        consumer_group_name=settings.APISIX_FREEMIUM_CONSUMER_GROUP_NAME,
-    )
     access_token_expires = datetime.timedelta(days=settings.JWT_API_KEY_EXPIRE_DAYS)
+    jwt_subject = f"{user_id.hex}"
     access_token = JwtService.create_access_token(
-        api_key_subject, access_token_expires, settings.JWT_AUDIENCE, {}
+        jwt_subject, access_token_expires, settings.JWT_AUDIENCE, {}
     )
     api_key = ApiKey(
         id=api_key_id, user_id=user_id, token=access_token, description=description
@@ -51,13 +45,6 @@ async def delete_api_key_by_id(api_key_id: uuid.UUID, user_id: uuid.UUID) -> boo
     Returns: True if the api key was deleted, False otherwise.
 
     """
-    stored_api_key = await ApiKey.get_by_ids(api_key_id, user_id)
-
-    if not stored_api_key:
-        return False
-
-    api_key_subject = f"{user_id.hex}_{api_key_id.hex}"
-    await get_apisix_client().delete_consumer(api_key_subject)
     return await ApiKey.delete_by_ids(api_key_id, user_id)
 
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -11,6 +11,7 @@ import bcrypt
 from starlette import status
 
 from ..config import settings
+from ..datasources.api_gateway.apisix.apisix_client import get_apisix_client
 from ..datasources.cache.redis import get_redis
 from ..datasources.db.models import User
 from ..models.types import passwordType
@@ -52,6 +53,27 @@ class UserService:
 
     def __init__(self):
         self.jwt_service = JwtService()
+
+    async def _create_new_user(self, email: str, password: passwordType) -> User:
+        """
+        Creates a new user, registers them as an APISIX consumer, and saves them to the database.
+
+        Args:
+            email: User's email address.
+            password: Plain-text password.
+
+        Returns:
+            User: The created user object.
+        """
+        hashed_password = self.hash_password(password)
+        user_uuid = uuid.uuid4()
+        await get_apisix_client().upsert_consumer(
+            f"{user_uuid.hex}",
+            consumer_group_name=settings.APISIX_FREEMIUM_CONSUMER_GROUP_NAME,
+        )
+        user = User(id=user_uuid, email=email, hashed_password=hashed_password)
+        await user.create()
+        return user
 
     def emit_access_token(self, user_id: uuid.UUID) -> Token:
         access_token_expires = timedelta(days=settings.JWT_AUTH_SERVICE_EXPIRE_DAYS)
@@ -157,11 +179,8 @@ class UserService:
             raise TemporaryTokenNotValid(f"Temporary token not valid for {email}")
         if await User.get_by_email(email):
             raise UserAlreadyExists(f"User with email {email} already exists")
-        hashed_password = self.hash_password(password)
-        user_uuid = uuid.uuid4()
-        user = User(id=user_uuid, email=email, hashed_password=hashed_password)
-        await user.create()
-        return user_uuid
+        user = await self._create_new_user(email, password)
+        return user.id
 
     async def authenticate_user(
         self, email: str, password: passwordType
@@ -196,10 +215,7 @@ class UserService:
             random_password = SecretStr(
                 secrets.token_hex(64)
             )  # Random password so user can change it afterward
-            hashed_password = self.hash_password(random_password)
-            user_uuid = uuid.uuid4()
-            user = User(id=user_uuid, email=email, hashed_password=hashed_password)
-            await user.create()
+            user = await self._create_new_user(email, random_password)
         return self.emit_access_token(user.id)
 
     async def change_password(

--- a/app/tests/routers/test_api_keys.py
+++ b/app/tests/routers/test_api_keys.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 
 import faker
 
-from app.datasources.api_gateway.apisix.apisix_client import get_apisix_client
 from app.datasources.db.connector import db_session_context
 from app.main import app
 
@@ -17,24 +16,13 @@ from ..datasources.db.factory import generate_random_user
 fake = faker.Faker()
 
 
-class TestClientWithTearDown(TestClient):
-
-    def tearDown(self):
-        get_apisix_client.cache_clear()
-
-    def request(self, method, url, *args, **kwargs):
-        response = super().request(method, url, *args, **kwargs)
-        self.tearDown()
-        return response
-
-
 class TestApiKeys(AsyncDbTestCase):
     client: TestClient
 
     @db_session_context
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.client = TestClientWithTearDown(app)
+        self.client = TestClient(app)
         user_service = UserService()
         user, password = await generate_random_user()
         self.user = user

--- a/app/tests/services/test_api_key_service.py
+++ b/app/tests/services/test_api_key_service.py
@@ -1,13 +1,10 @@
 import uuid
-from unittest.mock import patch
 
 import faker
 
-from app.datasources.api_gateway.apisix.apisix_client import get_apisix_client
 from app.datasources.db.connector import db_session_context
 from app.routers.auth import get_jwt_info_from_auth_token
 
-from ...datasources.api_gateway.exceptions import ApiGatewayRequestError
 from ...datasources.db.models import ApiKey
 from ...models.api_key import ApiKeyPublic
 from ...services.api_key_service import (
@@ -24,22 +21,10 @@ fake = faker.Faker()
 
 class TestApiKeyService(AsyncDbTestCase):
 
-    def setUp(self):
-        get_apisix_client.cache_clear()
-
-    def tearDown(self):
-        get_apisix_client.cache_clear()
-
     @db_session_context
     async def test_generate_api_key(self):
         user, _ = await generate_random_user()
-        freemium_consumer_group_name = "freemium_consumer_group"
-        await get_apisix_client().add_consumer_group(freemium_consumer_group_name)
-        with patch(
-            "app.config.settings.APISIX_FREEMIUM_CONSUMER_GROUP_NAME",
-            freemium_consumer_group_name,
-        ):
-            api_key = await generate_api_key(user.id, description="Api key for testing")
+        api_key = await generate_api_key(user.id, description="Api key for testing")
         self.assertIsNotNone(api_key)
         stored_api_key = await ApiKey.get_by_ids(api_key.id, user.id)
         self.assertEqual(api_key.id, stored_api_key.id)
@@ -47,15 +32,9 @@ class TestApiKeyService(AsyncDbTestCase):
         self.assertEqual(api_key.token, stored_api_key.token)
         self.assertEqual(api_key.description, stored_api_key.description)
 
-        api_key_subject = f"{user.id.hex}_{api_key.id.hex}"
-        apisix_consumer = await get_apisix_client().get_consumer(api_key_subject)
-        self.assertIsNotNone(apisix_consumer)
-        self.assertEqual(
-            apisix_consumer.consumer_group_name, freemium_consumer_group_name
-        )
-
         # The subject and key are generated correctly.
         decoded_token = await get_jwt_info_from_auth_token(api_key.token)
+        api_key_subject = f"{user.id.hex}"
         self.assertEqual(api_key_subject, decoded_token["sub"])
         self.assertEqual(api_key_subject, decoded_token["key"])
 
@@ -68,17 +47,12 @@ class TestApiKeyService(AsyncDbTestCase):
         api_key = await generate_api_key(user.id, description="Api key for testing")
         stored_api_key = await ApiKey.get_by_ids(api_key.id, user.id)
         self.assertIsNotNone(stored_api_key)
-        api_key_subject = f"{user.id.hex}_{api_key.id.hex}"
-        apisix_consumer = await get_apisix_client().get_consumer(api_key_subject)
-        self.assertIsNotNone(apisix_consumer)
 
         result = await delete_api_key_by_id(api_key.id, user.id)
         self.assertTrue(result)
 
         stored_api_key = await ApiKey.get_by_ids(api_key.id, user.id)
         self.assertIsNone(stored_api_key)
-        with self.assertRaises(ApiGatewayRequestError):
-            await get_apisix_client().get_consumer(api_key_subject)
 
     @db_session_context
     async def test_get_api_key_by_ids(self):

--- a/app/tests/services/test_user_service.py
+++ b/app/tests/services/test_user_service.py
@@ -1,7 +1,11 @@
 import uuid
+from unittest.mock import patch
 
 import faker
 
+from app.datasources.api_gateway.apisix.apisix_client import get_apisix_client
+
+from ...datasources.cache.redis import get_redis
 from ...datasources.db.connector import db_session_context
 from ...datasources.db.models import User
 from ...models.types import passwordType
@@ -21,6 +25,12 @@ class TestApiKeyService(AsyncDbTestCase):
 
     def setUp(self):
         self.user_service = UserService()
+        get_apisix_client.cache_clear()
+        get_redis().flushall()
+
+    def tearDown(self):
+        get_apisix_client.cache_clear()
+        get_redis().flushall()
 
     @db_session_context
     async def test_change_password(self):
@@ -90,14 +100,54 @@ class TestApiKeyService(AsyncDbTestCase):
         )
 
     @db_session_context
+    async def test_register_user(self):
+        self.assertEqual(await User.count(), 0)
+        random_email_a = "random.1@safe.global"
+        random_password = passwordType(fake.password())
+        pre_register_token = self.user_service.pre_register_user(random_email_a)
+        registered_user_a_id = await self.user_service.register_user(
+            random_email_a, random_password, pre_register_token
+        )
+        self.assertEqual(await User.count(), 1)
+        apisix_consumer_a_name = f"{registered_user_a_id.hex}"
+        apisix_consumer_a = await get_apisix_client().get_consumer(
+            apisix_consumer_a_name
+        )
+        self.assertIsNotNone(apisix_consumer_a)
+
+        freemium_consumer_group_name = "freemium_consumer_group"
+        await get_apisix_client().add_consumer_group(freemium_consumer_group_name)
+        with patch(
+            "app.config.settings.APISIX_FREEMIUM_CONSUMER_GROUP_NAME",
+            freemium_consumer_group_name,
+        ):
+            random_email_b = "random.2@safe.global"
+            random_password = passwordType(fake.password())
+            pre_register_token = self.user_service.pre_register_user(random_email_b)
+            registered_user_id_b = await self.user_service.register_user(
+                random_email_b, random_password, pre_register_token
+            )
+            self.assertEqual(await User.count(), 2)
+            apisix_consumer_b_name = f"{registered_user_id_b.hex}"
+            apisix_consumer_b = await get_apisix_client().get_consumer(
+                apisix_consumer_b_name
+            )
+            self.assertIsNotNone(apisix_consumer_b)
+
+    @db_session_context
     async def test_login_or_register(self):
         self.assertEqual(await User.count(), 0)
-        random_email = "random@safe.global"
+        random_email = "random.google.email@safe.global"
         # Email must be registered
         token = await self.user_service.login_or_register(random_email)
         self.assertEqual(await User.count(), 1)
         self.assertIsNotNone(token.access_token)
         self.assertEqual(token.token_type, "bearer")
+        user = await User.get_by_email(random_email)
+        assert user is not None
+        apisix_consumer_name = f"{user.id.hex}"
+        apisix_consumer = await get_apisix_client().get_consumer(apisix_consumer_name)
+        self.assertIsNotNone(apisix_consumer)
 
         # Login after register
         token_2 = await self.user_service.login_or_register(random_email)


### PR DESCRIPTION
- Related with #109 

Due it is necessary to maintain the rate limit per consumer in Apisix, it is necessary that all Api Keys of each user share the same consumer id. For this reason the consumer is created in Apisix when registering the user, and then the user id is assigned as the sub/key of all Api keys.

In this way all Api keys share the same rate-limit.
